### PR TITLE
Handle use from WSL

### DIFF
--- a/browser_linux.go
+++ b/browser_linux.go
@@ -3,6 +3,9 @@
 package browser
 
 import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
 	"net/url"
 	"os/exec"
 )
@@ -13,6 +16,19 @@ func Open(u string) (err error) {
 	if err != nil {
 		return
 	}
+
+	// read /proc/version which contains OS version info
+	data, err := ioutil.ReadFile("/proc/version")
+	if err != nil {
+		return fmt.Errorf("cannot read /proc/version: %v", err)
+	}
+
+	// version is in format: Linux version 4.4.0-17134-Microsoft
+	if bytes.Contains(data, []byte("-Microsoft")) {
+		_, err = exec.Command("cmd.exe", "/c", "start", u).Output()
+		return
+	}
+
 	_, err = exec.Command("xdg-open", u).Output()
 	return
 }


### PR DESCRIPTION
WSL (Windows Subsystem for Linux, or Bash on Windows) doesn't come with `xdg-open` (and even if installed, it doesn't currently work). So this package cannot currently be used from WSL.

This PR checks if the process is running under WSL, and if true, it will call `cmd.exe start`.

It checks for WSL by reading `/proc/version`, which is in the format: `Linux version 4.4.0-17134-Microsoft`.
If the file contains `-Microsoft`, I think it's safe to assume we're under WSL.